### PR TITLE
fix: 조회 api 응답값 수정 #13

### DIFF
--- a/src/main/java/com/sopt/mcdonald/burger/api/dto/response/BurgerResponse.java
+++ b/src/main/java/com/sopt/mcdonald/burger/api/dto/response/BurgerResponse.java
@@ -1,9 +1,6 @@
 package com.sopt.mcdonald.burger.api.dto.response;
 
-import com.sopt.mcdonald.burger.domain.AllergyEntity;
-import com.sopt.mcdonald.burger.domain.BurgerEntity;
-import com.sopt.mcdonald.burger.domain.Allergy;
-import com.sopt.mcdonald.burger.domain.NutritionDto;
+import com.sopt.mcdonald.burger.domain.*;
 
 import java.util.List;
 
@@ -12,7 +9,8 @@ public record BurgerResponse(
         String burger_name,
         String burger_name_eng,
         String description,
-        NutritionDto nutrition,
+        NutritionDto nutritionContent,
+        NutritionDto nutritionRef,
         List<String> allergy,
         String origin
 ) {
@@ -23,6 +21,7 @@ public record BurgerResponse(
                 burgerEntity.getBurgerNameEng(),
                 burgerEntity.getDescription(),
                 buildNutrition(burgerEntity),
+                buildNutritionRef(burgerEntity),
                 buildAllergies(burgerEntity),
                 burgerEntity.getOrigin()
         );
@@ -38,6 +37,19 @@ public record BurgerResponse(
                 burgerEntity.getSaturatedFat(),
                 burgerEntity.getSodium(),
                 burgerEntity.getCaffeine()
+        );
+    }
+
+    private static NutritionDto buildNutritionRef(BurgerEntity burgerEntity) {
+        return NutritionDto.of(
+                burgerEntity.getWeightGRef(),
+                burgerEntity.getWeightMlRef(),
+                burgerEntity.getCaloriesRef(),
+                burgerEntity.getSugarRef(),
+                burgerEntity.getProteinRef(),
+                burgerEntity.getSaturatedFatRef(),
+                burgerEntity.getSodiumRef(),
+                burgerEntity.getCaffeineRef()
         );
     }
 

--- a/src/main/java/com/sopt/mcdonald/burger/domain/BurgerEntity.java
+++ b/src/main/java/com/sopt/mcdonald/burger/domain/BurgerEntity.java
@@ -53,6 +53,30 @@ public class BurgerEntity {
     @Column(name = "caffeine")
     private Integer caffeine;
 
+    @Column(name = "weight_g_ref")
+    private Integer weightGRef;
+
+    @Column(name = "weight_ml_ref")
+    private Integer weightMlRef;
+
+    @Column(name = "calories_ref")
+    private Integer caloriesRef;
+
+    @Column(name = "sugar_ref")
+    private Integer sugarRef;
+
+    @Column(name = "protein_ref")
+    private Integer proteinRef;
+
+    @Column(name = "saturated_fat_ref")
+    private Integer saturatedFatRef;
+
+    @Column(name = "sodium_ref")
+    private Integer sodiumRef;
+
+    @Column(name = "caffeine_ref")
+    private Integer caffeineRef;
+
     @OneToMany(mappedBy = "burgerEntity", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<AllergyEntity> allergies;
 


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! feat: {제목} #{이슈번호} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 

## ✨ 해당 이슈 번호 ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #13 

## ✨ todo ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->
기존에 NutritionContent만 응답으로 보내던 걸 NutritionRef도 함께 보내 영양조회 중 함량, 영양소 기준치 모두 조회가 가능토록 수정했습니다. 
![image](https://github.com/user-attachments/assets/2c6fcb5d-826f-46ae-a65e-03102a770586)


## 📌 내가 알게 된 부분
<!-- 새롭게 알게 된 부분을 적자 (기록하면서 개발하기!) -->
- 

## 📌 질문할 부분 
-
